### PR TITLE
fix: timeouts

### DIFF
--- a/pkg/collector/warden_collector.go
+++ b/pkg/collector/warden_collector.go
@@ -136,6 +136,8 @@ func (w WardenCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- pendingKeys
 	ch <- keychains
 	ch <- keychainRequests
+	ch <- keychain
+	ch <- keychainSignatureRequests
 }
 
 func (w WardenCollector) Collect(ch chan<- prometheus.Metric) {
@@ -289,5 +291,5 @@ func (w WardenCollector) Collect(ch chan<- prometheus.Metric) {
 		)
 	}
 
-	log.Debug("Stop collecting", zap.String("metric", spacesMetricName))
+	log.Info("Stop collecting", zap.String("metric", spacesMetricName))
 }

--- a/pkg/collector/warp_collector.go
+++ b/pkg/collector/warp_collector.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql" // mysql driver
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 
 	"github.com/warden-protocol/warden-exporter/pkg/config"
 	log "github.com/warden-protocol/warden-exporter/pkg/logger"
@@ -114,6 +115,7 @@ func (w WarpCollector) Collect(ch chan<- prometheus.Metric) {
 			}...,
 		)
 	}
+	log.Info("Stop collecting", zap.String("metric", "warp"))
 }
 
 func queryWarpUsers(db *sql.DB) (int, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,8 +20,8 @@ func configError(msg string) error {
 type Config struct {
 	Addr             string `env:"GRPC_ADDR" envDefault:"grpc.buenavista.wardenprotocol.org:443"`
 	TLS              bool   `env:"GRPC_TLS_ENABLED" envDefault:"true"`
-	Timeout          int    `env:"GRPC_TIMEOUT_SECONDS" envDefault:"15"`
-	TTL              int    `env:"TTL" envDefault:"30"`
+	Timeout          int    `env:"GRPC_TIMEOUT_SECONDS" envDefault:"45"`
+	TTL              int    `env:"TTL" envDefault:"60"`
 	ChainID          string `env:"CHAIN_ID" envDefault:"buenavista-1"`
 	WardenMetrics    bool   `env:"WARDEN_METRICS" envDefault:"true"`
 	ValidatorMetrics bool   `env:"VALIDATOR_METRICS" envDefault:"true"`


### PR DESCRIPTION
- make exporter perform better, running collectors as routines
- increasing default timeouts since processes take quite a while to perform
- adding /healthz endpoint to check the process health