### PR TITLE
fix: openai costs parsing error

### DIFF
--- a/pkg/collector/openai_collector.go
+++ b/pkg/collector/openai_collector.go
@@ -124,9 +124,9 @@ func (o OpenAICollector) openAICollectCosts(
 	for _, bucket := range costsResponse.Data {
 		for _, res := range bucket.Results {
 			valueStr := string(res.Amount.Value)
-			value, err := strconv.ParseFloat(valueStr, 64)
-			if err != nil {
-				log.Error(fmt.Sprintf("error parsing amount value '%s': %s", valueStr, err))
+			value, parseErr := strconv.ParseFloat(valueStr, 64)
+			if parseErr != nil {
+				log.Error(fmt.Sprintf("error parsing amount value '%s': %s", valueStr, parseErr))
 				continue
 			}
 			total += value


### PR DESCRIPTION
Fixed JSON unmarshal error caused by OpenAI API returning `amount.value` in inconsistent formats (sometimes as float, sometimes as string). 
Changed the struct field type to `json.Number` and explicitly parse values using `strconv.ParseFloat()` to handle both formats correctly.